### PR TITLE
Interview function edit destroy

### DIFF
--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -37,3 +37,19 @@
     font-size: 15px;
     background: #fff;
 }
+
+.edit_btn {
+    color: #fff;
+    background-color: #868e96;
+    border-color: #868e96;
+    margin-bottom: 10px;
+    margin-top: 10px;
+}
+
+.delete_btn {
+    color: #fff;
+    background-color: #dc3545;
+    border-color: #dc3545;
+    margin-bottom: 10px;
+    margin-top: 10px;
+}

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,4 +1,6 @@
 class InterviewsController < ApplicationController
+  before_action :get_interview, only: [:edit, :update, :destroy]
+
   def index
     @interviews = current_user.interviews.order(start_time: :asc)
   end
@@ -9,10 +11,29 @@ class InterviewsController < ApplicationController
 
   def create
     @interview = Interview.new(interview_params)
-    if @interview.save
+    if @interview.user_id == current_user.id && @interview.save
       redirect_to user_interviews_path, notice: "面接日程を追加しました。"
     else
       render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if  @interview.user_id == current_user.id && @interview.update(interview_params)
+      redirect_to user_interviews_path, notice: "面接日程を更新しました。"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if  @interview.user_id == current_user.id && @interview.destroy
+      redirect_to user_interviews_path, notice: "面接日程を削除しました。"
+    else
+      render :index
     end
   end
 
@@ -20,5 +41,9 @@ class InterviewsController < ApplicationController
 
   def interview_params
     params.require(:interview).permit(:start_time).merge(user_id: params[:user_id])
+  end
+
+  def get_interview
+    @interview = Interview.find(params[:id])
   end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,5 +1,5 @@
 class InterviewsController < ApplicationController
-  before_action :get_interview, only: [:edit, :update, :destroy]
+  before_action :set_interview, only: [:edit, :update, :destroy]
 
   def index
     @interviews = current_user.interviews.order(start_time: :asc)
@@ -43,7 +43,7 @@ class InterviewsController < ApplicationController
     params.require(:interview).permit(:start_time).merge(user_id: params[:user_id])
   end
 
-  def get_interview
+  def set_interview
     @interview = Interview.find(params[:id])
   end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -11,7 +11,7 @@ class InterviewsController < ApplicationController
 
   def create
     @interview = Interview.new(interview_params)
-    if @interview.user_id == current_user.id && @interview.save
+    if @interview.save
       redirect_to user_interviews_path, notice: "面接日程を追加しました。"
     else
       render :new
@@ -22,7 +22,7 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    if  @interview.user_id == current_user.id && @interview.update(interview_params)
+    if @interview.update(interview_params)
       redirect_to user_interviews_path, notice: "面接日程を更新しました。"
     else
       render :edit
@@ -30,7 +30,7 @@ class InterviewsController < ApplicationController
   end
 
   def destroy
-    if  @interview.user_id == current_user.id && @interview.destroy
+    if @interview.destroy
       redirect_to user_interviews_path, notice: "面接日程を削除しました。"
     else
       render :index

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,32 @@
+<%= render "layouts/header" %>
+<% if @interview.errors.any? %>
+  <div id="error_explanation">
+    <% @interview.errors.full_messages.each do |message| %>
+      <%= message %>
+    <% end %>
+  </div>
+<% end %>
+<h1>面接日程の編集</h1>
+  <%= form_for [current_user,@interview] do |f| %>
+  <div class="field">
+  開始日時<br />
+  <%= raw sprintf(
+    f.datetime_select(
+      :start_time,
+      {
+        start_year:     Time.zone.now.year,
+        end_year:       Time.zone.now.next_year.year,
+        default:        1.days.from_now.since(1.hours),
+        use_month_numbers: true,
+        minute_step: 10,
+        date_separator: '%s',
+        datetime_separator: '%s',
+        time_separator: '%s'
+      },
+      { class: 'form-controll'}
+    ),
+    '年 ', '月 ', '日 ', '時 ') + '分'
+  %>
+  </div>
+  <%=f.submit "日時を登録する", class:"btn" %>
+  <% end %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -8,25 +8,25 @@
 <% end %>
 <h1>面接日程の編集</h1>
   <%= form_for [current_user,@interview] do |f| %>
-  <div class="field">
-  開始日時<br />
-  <%= raw sprintf(
-    f.datetime_select(
-      :start_time,
-      {
-        start_year:     Time.zone.now.year,
-        end_year:       Time.zone.now.next_year.year,
-        default:        1.days.from_now.since(1.hours),
-        use_month_numbers: true,
-        minute_step: 10,
-        date_separator: '%s',
-        datetime_separator: '%s',
-        time_separator: '%s'
-      },
-      { class: 'form-controll'}
-    ),
-    '年 ', '月 ', '日 ', '時 ') + '分'
-  %>
-  </div>
-  <%=f.submit "日時を登録する", class:"btn" %>
+    <div class="field">
+      開始日時<br />
+      <%= raw sprintf(
+        f.datetime_select(
+          :start_time,
+          {
+            start_year:     Time.zone.now.year,
+            end_year:       Time.zone.now.next_year.year,
+            default:        1.days.from_now.since(1.hours),
+            use_month_numbers: true,
+            minute_step: 10,
+            date_separator: '%s',
+            datetime_separator: '%s',
+            time_separator: '%s'
+          },
+          { class: 'form-controll'}
+        ),
+      '年 ', '月 ', '日 ', '時 ') + '分'
+      %>
+    </div>
+    <%=f.submit "日時を登録する", class:"btn" %>
   <% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -24,12 +24,12 @@
       </td>
       <td>
         <div class="text-center">
-          編集
+          <%= link_to "編集", edit_user_interview_path(current_user, interview), class:"btn edit_btn" %>
         </div>
       </td>
       <td>
         <div class="text-center">
-          削除
+          <%= link_to "削除", user_interview_path(current_user, interview), method: :delete , class:"btn delete_btn", data: { confirm:'本当に削除しますか？'} %>
         </div>
       </td>
       </tr>


### PR DESCRIPTION
# やりたかったこと
---


-面接日程の削除・編集機能 

...

# やったこと
----

- interviews_controllerにactionの定義
- 編集画面の追加
- 編集・削除ボタンの追加
...


# 動作確認方法
---


- [ ] 面接日程の削除
・トップページから「自分の面接一覧」ボタンを押すと自分の面接候補日一覧の画面に進みます。そこで削除ボタンを押すと削除できます。
- [ ] 面接日程の編集
・トップページから「自分の面接一覧」ボタンを押すと自分の面接候補日一覧の画面に進みます。そこで編集ボタンを押すと編集画面に遷移して編集ができます。
...

# その他
---
herokuのURLです。
https://e-navigator-kai815.herokuapp.com/

また1つミスをしてしまいました。申し訳ございません！
誤ってfeedforce/e-navigatorの方でもプルリクエスト作ってしまったみたいなのです。
下記が誤ったプルリクエストのURLです。
https://github.com/feedforce/e-navigator/pull/28

削除しようと思い、下記を参考にした結果、
https://qiita.com/Yorinton/items/adf1ebf922c26ddb26a0
https://qiita.com/megu_ma/items/7533b4327dc110a9e2b8
http://tweeeety.hateblo.jp/entry/2015/06/10/220841

$ git push --delete origin branch-nameのコマンドをやればいいのかなと思いながらも、勝手に判断してやるのは良くないと思いっております。この場合はどうしたら良いでしょうか？
ご教授お願い致します。
お忙しいところ大変申し訳ございません！